### PR TITLE
Remove `version` from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 volumes:
     prometheus_data: {}
     grafana_data: {}


### PR DESCRIPTION
`version` is obsolete in docker-compose files, resulting in a warning message, if it's used nevertheless:

```shell
$ docker compose up
WARN[0000] /Users/a1dbe91/Util/am2ch/docker-compose.yml: `version` is obsolete
```

This PR removes the `version` information from the docker-compose.yml thereby getting rid of the error message

