### PR TITLE
update cadvisor container tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
 services:
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor
+    image: gcr.io/cadvisor/cadvisor:v0.47.2
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:rw


### PR DESCRIPTION
cadvisor:latest container tag is outdated, which will result in cadvisor failing to start with the error: "Cannot detect current cgroup on cgroup v2", see here: https://github.com/google/cadvisor/issues/3481